### PR TITLE
Handle bad songs.

### DIFF
--- a/include/linkedlist.h
+++ b/include/linkedlist.h
@@ -25,6 +25,7 @@ void free_list(LinkedList* list);
 LLNode* create_node(const char* path, const char* dir);
 // Assumes both next and prev of the node are NULL
 void add_single_node(LinkedList* list, LLNode* node);
+void remove_single_node(LinkedList* list, LLNode* node);
 
 /*
 main store a list created with create_list(),

--- a/include/songhandler.h
+++ b/include/songhandler.h
@@ -8,4 +8,4 @@
 int loadSong(xmp_context c, struct xmp_module_info *mi, char *path, char *dir, int *isFT);
 uint32_t searchsong(const char *searchPath, LinkedList *list);
 //int loadSongMemory(char *path, char *dir);
-int loadSongMemory(xmp_context c, struct xmp_module_info *mi, char *path, char *dir, int *isFT);
+int loadSongMemory(xmp_context c, struct xmp_module_info *mi, char *path, char *dir, int *isFT, bool* released);

--- a/source/linkedlist.c
+++ b/source/linkedlist.c
@@ -63,3 +63,34 @@ void add_single_node(LinkedList* list, LLNode* node) {
         list->size++;
     }
 }
+
+void remove_single_node(LinkedList* list, LLNode* node) {
+    //just some simple checks
+    //quit if list is null or size is 0
+    //or if node is null
+    //if node previous is null, is expected to be list front. if not, quit
+    //if node next is null, is expected to be list back. if not, quit
+    if (!list || list->size == 0 || !node || (node->prev == NULL && list->front != node) || (node->next == NULL && list->back != node))
+        return;
+    
+    if(list->front == node)
+        list->front = node->next;
+    if(list->back == node)
+        list->back = node->prev;
+
+    if(node->prev)
+        node->prev->next = node->next;
+    if(node->next)
+        node->next->prev = node->prev;
+
+    free(node->track_path);
+    free(node->directory);
+    free(node);
+
+    list->size--;
+
+    if(list->size == 0) {
+        list->front = NULL;
+        list->back = NULL;
+    }
+}

--- a/source/sndthr.c
+++ b/source/sndthr.c
@@ -8,9 +8,9 @@
 #define O3DS_BLOCK 4096
 // can someone find sweet spot?
 
-extern int runSound, playSound;
+extern volatile int runSound, playSound;
 extern struct xmp_frame_info fi;
-extern uint64_t render_time;
+extern volatile uint64_t render_time;
 
 extern volatile uint32_t _PAUSE_FLAG;
 

--- a/source/song_info.c
+++ b/source/song_info.c
@@ -17,8 +17,8 @@ static uint8_t old_fxt[256];
 static uint8_t old_fxp[256];
 static uint8_t old_f2t[256];
 static uint8_t old_f2p[256];
-extern uint64_t render_time;
-extern uint64_t screen_time;
+extern volatile uint64_t render_time;
+extern volatile uint64_t screen_time;
 extern volatile uint32_t _PAUSE_FLAG;
 void show_generic_info(struct xmp_frame_info *fi, struct xmp_module_info *mi,
                        PrintConsole *top, PrintConsole *bot, int isN3DS, int cur_subsong) {


### PR DESCRIPTION
- Adds ability to remove item from linked list
- Avoid double xmp_release_module, leads to double free
- Make loading next or previous song a bit simpler
- Add ability to check all songs at load, but disabled by default
- Fix possible uninitialized xmp_context on early exit
- Add "volatile" to extern volatile vars